### PR TITLE
Onehot encoding optimization

### DIFF
--- a/src/main/anovos/data_transformer/transformers.py
+++ b/src/main/anovos/data_transformer/transformers.py
@@ -326,7 +326,6 @@ def cat_to_num_unsupervised(spark, idf, list_of_cols='all', drop_cols=[], method
             else:
                 selected_cols = [e for e in odf.columns if e not in (i + '_vec', i + '_index', 'tmp')]
             odf = odf.select(selected_cols)
-            write_dataset(odf, "/tmp/", "parquet",{'mode':'overwrite'})
         if skipped_cols:
             warnings.warn(
                 "Columns dropped from one-hot encoding due to high cardinality: " + (',').join(skipped_cols))

--- a/src/main/anovos/data_transformer/transformers.py
+++ b/src/main/anovos/data_transformer/transformers.py
@@ -321,7 +321,7 @@ def cat_to_num_unsupervised(spark, idf, list_of_cols='all', drop_cols=[], method
             else:
                 selected_cols = [e for e in odf.columns if e not in (i + '_vec', i + '_index', 'tmp')]
             odf = odf.select(selected_cols)
-            if skipped_cols > 0:
+            if skipped_cols:
                 warnings.warn(
                     "Columns dropped from one-hot encoding due to high cardinality: " + (',').join(skipped_cols))
     else:

--- a/src/main/anovos/data_transformer/transformers.py
+++ b/src/main/anovos/data_transformer/transformers.py
@@ -242,6 +242,7 @@ def cat_to_num_unsupervised(spark, idf, list_of_cols='all', drop_cols=[], method
     :param model_path: If pre_existing_model is True, this argument is path for referring the pre-saved model.
                        If pre_existing_model is False, this argument can be used for saving the model.
                        Default "NA" means there is neither pre existing model nor there is a need to save one.
+    :param cardinality_threshold: Defines threshold to skip columns with higher cardinality values from encoding. Default value is 100.
     :param output_mode: "replace", "append".
                         “replace” option replaces original columns with transformed column. “append” option append transformed
                         column to the input dataset with a postfix "_index" e.g. column X is appended as X_index.


### PR DESCRIPTION
Added changes for one hot encoding optimization 

1. Added cardinality threshold 
2. Changed select + alias to rdd.map.toDF
3. Modified docstrings
4. Set défault cardinality threshold as 100