### PR TITLE
Ensure that input data is found in all scenarios

### DIFF
--- a/src/main/anovos/feature_recommender/featrec_init.py
+++ b/src/main/anovos/feature_recommender/featrec_init.py
@@ -66,10 +66,16 @@ def init_input_fer():
     -------
     Loading the Feature Explorer and Recommender (FER) Input DataFrame (FER corpus)
     """
-    site_path = site.getsitepackages()[0]
-    input_path_fer = os.path.join(
-        site_path, "anovos/feature_recommender/data/flatten_fr_db.csv"
+    local_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "data", "flatten_fr_db.csv"
     )
+    if os.path.exists(local_path):
+        input_path_fer = local_path
+    else:
+        site_path = site.getsitepackages()[0]
+        input_path_fer = os.path.join(
+            site_path, "anovos/feature_recommender/data/flatten_fr_db.csv"
+        )
     df_input_fer = pd.read_csv(input_path_fer)
     return df_input_fer
 


### PR DESCRIPTION
If Anovos is cloned from GitHub, the feature recommender input data is not found:

```shell
ImportError: Error importing 'anovos.feature_recommender.feature_recommendation': FileNotFoundError: [Errno 2] No such file or directory: '/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/anovos/feature_recommender/data/flatten_fr_db.csv'
```