### PR TITLE
Update drift validations

### DIFF
--- a/src/main/anovos/drift/validations.py
+++ b/src/main/anovos/drift/validations.py
@@ -21,28 +21,30 @@ def check_list_of_columns(
 
         idf_target = kwargs.get(target, "") or args[target_idx]
 
-        if isinstance(kwargs[columns], str):
-            if kwargs[columns] == "all":
+        cols_raw = kwargs.get(columns, "all")
+        if isinstance(cols_raw, str):
+            if cols_raw == "all":
                 num_cols, cat_cols, other_cols = attributeType_segregation(idf_target)
                 cols = num_cols + cat_cols
             else:
-                cols = [x.strip() for x in kwargs[columns].split("|")]
-        elif isinstance(kwargs[columns], list):
-            cols = kwargs[columns]
+                cols = [x.strip() for x in cols_raw.split("|")]
+        elif isinstance(cols_raw, list):
+            cols = cols_raw
         else:
             raise TypeError(
                 f"'{columns}' must be either a string or a list of strings."
-                f" Received {type(kwargs[columns])}."
+                f" Received {type(cols_raw)}."
             )
 
-        if isinstance(kwargs[drop], str):
-            drops = [x.strip() for x in kwargs[drop].split("|")]
-        elif isinstance(kwargs[drop], list):
-            drops = kwargs[drop]
+        drops_raw = kwargs.get(drop, [])
+        if isinstance(drops_raw, str):
+            drops = [x.strip() for x in drops_raw.split("|")]
+        elif isinstance(drops_raw, list):
+            drops = drops_raw
         else:
             raise TypeError(
                 f"'{drop}' must be either a string or a list of strings. "
-                f"Received {type(kwargs[columns])}."
+                f"Received {type(drops_raw)}."
             )
 
         final_cols = list(set(e for e in cols if e not in drops))
@@ -72,7 +74,7 @@ def check_distance_method(func=None, param="method_type"):
 
     @wraps(func)
     def validate(*args, **kwargs):
-        dist_distance_methods = kwargs[param]
+        dist_distance_methods = kwargs.get(param, "PSI")
 
         if isinstance(dist_distance_methods, str):
             if dist_distance_methods == "all":


### PR DESCRIPTION
If there is no input provided for list_of_cols, drop_cols and method_type when calling anovos.drift.detector.statistics, an KeyError (e.g. KeyError: 'method_type') is returned. 

This PR includes necessary changes to allow calling statistics without specifying the above mentioned variables, in other words, using the default values.