### PR TITLE
Latest jinja2 release breaks report generation on all current versions of Anovos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ scikit-learn==1.0.2
 sympy>=1.6,<=1.9
 matplotlib>=3.4.3,<=3.5.1
 datapane==0.12.0
+jinja2<3.1.0
 plotly>=5.2.1,<=5.6.0
 pyarrow<=7.0.0
 findspark==2.0.1


### PR DESCRIPTION
As far as I can see, this problem occurs with all currently released versions of Anovos as well. Jinja2 3.1.x was first released on March 24th 2022 ([PyPI release history](https://pypi.org/project/Jinja2/#history)), since then Anovos report generation will be broken on all new installations.

The proper way to fix this is an upgrade to the latest datapane release, i.e., debugging and merging #48. For now, pinning jinja2 to <3.1.0 is sufficient.

### Details

In `jinja2` 3.1.0, several deprecated imports are removed ([Diff](https://github.com/pallets/jinja/commit/824b4d3e5bb789cabd7cef74e57f4d802a7b2bfd)), which breaks `datapane` 0.12.0:

```shell
File "/home/runner/work/anovos-docs/anovos-docs/anovos/src/main/anovos/data_report/basic_report_generation.py", line 4, in <module>
    import datapane as dp
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/datapane/__init__.py", line 27, in <module>
    from .client.api import (
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/datapane/client/api/__init__.py", line 68, in <module>
    from .report.core import FontChoice, Report, ReportFormatting, ReportWidth, TextAlignment, TextReport
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/datapane/client/api/report/core.py", line 19, in <module>
    from jinja2 import Environment, FileSystemLoader, Markup, Template, contextfunction
ImportError: cannot import name 'Markup' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/bin/pdoc", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pdoc/cli.py", line 5[36](https://github.com/anovos/anovos-docs/runs/5704079330?check_suite_focus=true#step:10:36), in main
    for module in args.modules]
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pdoc/cli.py", line [53](https://github.com/anovos/anovos-docs/runs/5704079330?check_suite_focus=true#step:10:53)6, in <listcomp>
    for module in args.modules]
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pdoc/__init__.py", line 756, in __init__
    context=self._context, skip_errors=skip_errors)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pdoc/__init__.py", line 7[54](https://github.com/anovos/anovos-docs/runs/5704079330?check_suite_focus=true#step:10:54), in __init__
    m = Module(import_module(fullname),
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pdoc/__init__.py", line 224, in import_module
    raise ImportError(f'Error importing {module!r}: {e.__class__.__name__}: {e}')
ImportError: Error importing 'anovos.data_report.basic_report_generation': ImportError: cannot import name 'Markup' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py)
```

Source: [This API doc generation run](https://github.com/anovos/anovos-docs/runs/5704079330?check_suite_focus=true) 