### PR TITLE
fixed demo Dockerfile for spark 3.2.2

### DIFF
--- a/bin/spark-submit_docker.sh
+++ b/bin/spark-submit_docker.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
-spark-2.4.8-bin-hadoop2.7/bin/spark-submit \
+spark_version="$(spark/bin/spark-shell <<< sc.version | grep res0 | cut -f4 -d" ")"
+echo "Spark version is ${spark_version}"
+spark3_version="3.0.0"
+
+function version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" == "$1"; }
+
+if version_ge "${spark_version}" "${spark3_version}"; then
+	avro_package="org.apache.spark:spark-avro_2.12:${spark_version}"
+	histogrammar_jar="histogrammar_2.12-1.0.20.jar"
+	histogrammar_sql_jar="histogrammar-sparksql_2.12-1.0.20.jar"
+else
+	avro_package="org.apache.spark:spark-avro_2.11:${spark_version}"
+	histogrammar_jar="histogrammar_2.11-1.0.20.jar"
+	histogrammar_sql_jar="histogrammar-sparksql_2.11-1.0.20.jar"
+fi
+
+spark/bin/spark-submit \
 --deploy-mode client \
 --num-executors 1 \
 --executor-cores 2 \
@@ -13,14 +29,14 @@ spark-2.4.8-bin-hadoop2.7/bin/spark-submit \
 --conf spark.executor.extraJavaOptions=-XX:+UseCompressedOops \
 --conf spark.executor.extraJavaOptions="-Dlog4j.configuration=file:///log4j.properties" \
 --conf spark.driver.extraJavaOptions="-Dlog4j.configuration=file:///log4j.properties" \
---conf spark.kryo.referenceTracking=false \
+--conf spark.kryo.referenceTracking=true \
 --conf spark.network.timeout=18000s \
 --conf spark.executor.heartbeatInterval=12000s \
 --conf spark.dynamicAllocation.executorIdleTimeout=12000s \
 --conf spark.port.maxRetries=200 \
---packages org.apache.spark:spark-avro_2.11:2.4.0 \
+--packages "${avro_package}" \
 --conf spark.yarn.maxAppAttempts=1 \
---jars histogrammar_2.11-1.0.20.jar,histogrammar-sparksql_2.11-1.0.20.jar \
+--jars ${histogrammar_jar},${histogrammar_sql_jar} \
 --py-files anovos.zip \
 main.py \
 configs.yaml \

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -8,9 +8,11 @@ RUN add-apt-repository ppa:deadsnakes/ppa \
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
 
-RUN wget "https://downloads.apache.org/spark/spark-2.4.8/spark-2.4.8-bin-hadoop2.7.tgz" \
-    && tar -xzvf spark-2.4.8-bin-hadoop2.7.tgz \
-    && rm spark-2.4.8-bin-hadoop2.7.tgz
+RUN wget "https://downloads.apache.org/spark/spark-3.2.2/spark-3.2.2-bin-hadoop2.7.tgz" \
+    && tar -xzvf spark-3.2.2-bin-hadoop2.7.tgz \
+    && rm spark-3.2.2-bin-hadoop2.7.tgz
+
+RUN mv spark-3.2.2-bin-hadoop2.7 spark
 
 COPY bin/datapane_install ./datapane_install
 RUN ln -s /usr/bin/python3 /usr/bin/python \


### PR DESCRIPTION
Demo Docker image was failing for 2.4.8. Changed to 3.2.2 
Also modified spark submit shell script to be agnostic of spark version.
Tested local run successfully