### PR TITLE
Pass Docker credentials when running as reusable workflow

### DIFF
--- a/.github/workflows/anovos-notebook.yml
+++ b/.github/workflows/anovos-notebook.yml
@@ -131,3 +131,6 @@ jobs:
     needs:
       - notebooks
     uses: ./.github/workflows/local.yml
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -3,6 +3,11 @@ name: Local execution
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
   push:
     paths:
       - '.github/workflows/local.yml'


### PR DESCRIPTION
This is a bit weird, but it's allegedly the solution recommended by GitHub's support team: https://github.com/orgs/community/discussions/25238#discussioncomment-3247035