### PR TITLE
Reset mistakenly overwritten config & output report when running workloads locally in Docker container

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -30,8 +30,10 @@ jobs:
 
     - name: Prepare the demo
       run: |
+        mv ./data/metric_dictionary.csv .
         rm -rf ./data
         mkdir data
+        mv ./metric_dictionary.csv ./data
         mv ./examples/data/income_dataset ./data
         find ./data
         chmod +x ./local/run_workload.sh

--- a/config/configs_basic.yaml
+++ b/config/configs_basic.yaml
@@ -393,14 +393,6 @@ transformers:
       imputation: True
 
 
-    # autoencoder_latentFeatures:
-    #   list_of_cols: all
-    #   reduction_params: 0.5
-    #   sample_size: 10000
-    #   epochs: 20
-    #   batch_size: 256
-
-
 write_intermediate:
   file_path: "intermediate_data"
   file_type: csv

--- a/config/configs_basic.yaml
+++ b/config/configs_basic.yaml
@@ -71,7 +71,7 @@ timeseries_analyzer:
   max_days: 3600
 
 anovos_basic_report:
-  basic_report: False
+  basic_report: True
   report_args:
     id_col: ifa
     label_col: income

--- a/config/configs_basic.yaml
+++ b/config/configs_basic.yaml
@@ -66,7 +66,7 @@ timeseries_analyzer:
   auto_detection: True
   id_col: 'ifa'
   tz_offset: 'local'
-  inspection: False
+  inspection: True
   analysis_level: 'daily'
   max_days: 3600
 
@@ -76,6 +76,7 @@ anovos_basic_report:
     id_col: ifa
     label_col: income
     event_label: '>50K'
+    skip_corr_matrix: True
     output_path: report_stats
 
 #if anovos_basic_report.basic_report is True, then all configs below are ignored.
@@ -319,6 +320,17 @@ report_preprocessing:
     drift_detector: True
     outlier_charts: False
     source_path: "NA"
+
+report_generation:
+  master_path: 'report_stats'
+  id_col: 'ifa'
+  label_col: 'income'
+  corr_threshold: 0.4
+  iv_threshold: 0.02
+  drift_threshold_model: 0.1
+  dataDict_path: 'data/income_dataset/data_dictionary.csv'
+  metricDict_path: 'data/metric_dictionary.csv'
+  final_report_path: 'report_stats'
 
 transformers:
   numerical_mathops:

--- a/config/configs_basic.yaml
+++ b/config/configs_basic.yaml
@@ -66,7 +66,7 @@ timeseries_analyzer:
   auto_detection: True
   id_col: 'ifa'
   tz_offset: 'local'
-  inspection: True
+  inspection: False
   analysis_level: 'daily'
   max_days: 3600
 


### PR DESCRIPTION
Parts of this file were mistakenly deleted when PR #266 was squash-merged. This PR resets it to the state of #254 